### PR TITLE
Reducing size of morgan log output

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -25,7 +25,7 @@ app.use(
   })
 );
 app.use(cors());
-app.use(morgan('combined'));
+app.use(morgan('tiny'));
 app.use(passwordless.sessionSupport());
 app.use(passwordless.acceptToken());
 


### PR DESCRIPTION
To a much more readable:

':method :url :status :res[content-length] - :response-time ms'