### PR TITLE
Parse querystring and make request for results

### DIFF
--- a/client/src/Model/Model.elm
+++ b/client/src/Model/Model.elm
@@ -5,16 +5,27 @@ import Types exposing (..)
 import CountrySelect
 import ActivitySelect
 import CategorySelect
+import Router exposing (parseLocation)
+import Dict
 
 
 init : Navigation.Location -> ( Model, Cmd Msg )
 init location =
-    ( { location = location
+    ( { location = parseLocation location
+      , search = Dict.empty
+      , queryResults = "NONE"
       , email = ""
       , isLoggedIn = False
       , countrySelect = CountrySelect.initialModel
       , activitySelect = ActivitySelect.initialModel
       , categorySelect = CategorySelect.initialModel
       }
-    , Cmd.none
+    , redirectIfRoot location
     )
+
+
+redirectIfRoot { pathname } =
+    if pathname == "/" then
+        Navigation.modifyUrl "/#/"
+    else
+        Cmd.none

--- a/client/src/Model/QueryDecoder.elm
+++ b/client/src/Model/QueryDecoder.elm
@@ -1,0 +1,26 @@
+module QueryDecoder exposing (fetchQueryResultsCmd)
+
+import Http
+import Types exposing (..)
+import Json.Decode as Json
+
+
+fetchQueryResults model apiUrl =
+    Http.request
+        { method = "GET"
+        , headers = [ Http.header "Content-Type" "application/json" ]
+        , url = apiUrl ++ model.location.search
+        , body = Http.emptyBody
+        , expect = Http.expectJson (Json.at [ "data" ] Json.string)
+        , timeout = Nothing
+        , withCredentials = False
+        }
+
+
+fetchTaskCmd : (Result Http.Error String -> Msg) -> Model -> String -> Cmd Msg
+fetchTaskCmd msgConstructor model apiUrl =
+    Http.send msgConstructor (fetchQueryResults model apiUrl)
+
+
+fetchQueryResultsCmd model =
+    fetchTaskCmd QueryResults model "http://localhost:4000/query"

--- a/client/src/Router.elm
+++ b/client/src/Router.elm
@@ -6,6 +6,31 @@ import Views.Query
 import Views.Login
 import Views.About
 import Types exposing (..)
+import Navigation exposing (Location)
+import Util exposing (parseParams)
+
+
+parseLocation : Location -> Location
+parseLocation location =
+    { location
+        | hash =
+            String.split "?" location.hash
+                |> List.head
+                |> Maybe.withDefault ""
+        , search =
+            String.split "?" location.hash
+                |> List.drop 1
+                |> String.join "?"
+                |> String.append "?"
+    }
+
+
+onUrlChange : Location -> Model -> Model
+onUrlChange location model =
+    { model
+        | location = parseLocation location
+        , search = parseParams (.search (parseLocation location))
+    }
 
 
 matchView : Model -> Html Msg

--- a/client/src/Types.elm
+++ b/client/src/Types.elm
@@ -4,10 +4,14 @@ import Navigation
 import CountrySelect
 import ActivitySelect
 import CategorySelect
+import Dict exposing (Dict)
+import Http
 
 
 type alias Model =
     { location : Navigation.Location
+    , search : Dict.Dict String (List String)
+    , queryResults : String
     , email : String
     , isLoggedIn : Bool
     , countrySelect : CountrySelect.Model
@@ -24,4 +28,5 @@ type Msg
     | CountrySelectMsg CountrySelect.Msg
     | ActivitySelectMsg ActivitySelect.Msg
     | CategorySelectMsg CategorySelect.Msg
+    | QueryResults (Result Http.Error String)
     | NoOp

--- a/client/src/Update/Update.elm
+++ b/client/src/Update/Update.elm
@@ -2,16 +2,31 @@ module Update exposing (..)
 
 import Types exposing (..)
 import LoginDecoder exposing (requestLoginCodeCmd)
+import QueryDecoder exposing (fetchQueryResultsCmd)
 import CountrySelect
 import ActivitySelect
 import CategorySelect
+import Http
+import Router exposing (onUrlChange)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         UrlChange location ->
-            { model | location = location } ! []
+            let
+                newModel =
+                    onUrlChange location model
+
+                cmd =
+                    case newModel.location.hash of
+                        "#/query" ->
+                            fetchQueryResultsCmd newModel
+
+                        _ ->
+                            Cmd.none
+            in
+                ( newModel, cmd )
 
         SubmitLoginEmailForm ->
             ( model, requestLoginCodeCmd model )
@@ -39,6 +54,12 @@ update msg model =
                     CategorySelect.update subMsg model.categorySelect
             in
                 ( { model | categorySelect = updatedCategorySelectModel }, Cmd.map CategorySelectMsg categorySelectCmd )
+
+        QueryResults (Ok results) ->
+            ( { model | queryResults = results }, Cmd.none )
+
+        QueryResults (Err _) ->
+            ( model, Cmd.none )
 
         _ ->
             ( model, Cmd.none )

--- a/client/src/Views/Query.elm
+++ b/client/src/Views/Query.elm
@@ -6,4 +6,4 @@ import Html exposing (Html, text, div, form, input, button, span)
 
 view : Model -> Html Msg
 view model =
-    div [] [ text "Query results" ]
+    div [] [ text model.queryResults ]

--- a/server/src/router/query.route.js
+++ b/server/src/router/query.route.js
@@ -1,5 +1,5 @@
 export default () => (req, res) => {
   const { countries, categories } = req.query;
 
-  res.json('RECEIVED');
+  res.json({ data: 'RESULTS' });
 };


### PR DESCRIPTION
- parses `?countries[]=&categories=` querystring in elm app
- makes appropriate request to `/query?countries&categories` in node app
- redirects user from `"/"` to `"/#/"` when landing on home page