### PR TITLE
Adding query decoder

### DIFF
--- a/client/src/Data/DataTypes.elm
+++ b/client/src/Data/DataTypes.elm
@@ -2,7 +2,30 @@ module DataTypes exposing (..)
 
 
 type alias QueryResults =
-    { data : String }
+    { nMatches : Int
+    , totalMatches : Int
+    , maxScore : Float
+    , matches : List QueryResultsMatch
+    }
+
+
+type alias QueryResultsMatch =
+    { score : Float
+    , title : String
+    , type_ : String
+    , country : String
+    , year : Int
+    , url : String
+    , id : String
+    , body : List QueryResultsMatchBody
+    }
+
+
+type alias QueryResultsMatchBody =
+    { tags : List String
+    , text : String
+    , offset : Int
+    }
 
 
 type alias HomeDataResults =

--- a/client/src/Helpers/HomeData.elm
+++ b/client/src/Helpers/HomeData.elm
@@ -17,6 +17,9 @@ removeChildren taxonomies =
             )
 
 
+getFirstLevelChildren :
+    Taxonomy
+    -> List { enabled : Bool, id : String, name : String, children : HomeDataChildren }
 getFirstLevelChildren taxonomy =
     (\(HomeDataChildren children) -> children) taxonomy.children
 

--- a/client/src/Model/Model.elm
+++ b/client/src/Model/Model.elm
@@ -46,7 +46,7 @@ init : Flags -> Navigation.Location -> ( Model, Cmd Msg )
 init flags location =
     ( { location = parseLocation location
       , search = Dict.empty
-      , queryResults = { data = "NONE" }
+      , queryResults = { nMatches = 0, totalMatches = 0, maxScore = 0, matches = [] }
       , homeData =
             { id = ""
             , enabled = False

--- a/client/src/Views/Query.elm
+++ b/client/src/Views/Query.elm
@@ -15,6 +15,6 @@ view model =
         , div [ class "ml5 w-100" ]
             [ QueryNavBar.view model
             , SelectedCategories.view model
-            , text model.queryResults.data
+            , text ((toString model.queryResults.nMatches) ++ " results found")
             ]
         ]

--- a/server/src/fixtures/query-results.js
+++ b/server/src/fixtures/query-results.js
@@ -1,0 +1,23 @@
+export default {
+  n_matches: 10,
+  total_matches: 100,
+  max_score: 1.5,
+  matches: [
+    {
+      score: 1.5,
+      title: 'Title',
+      type: 'act',
+      country: 'MM',
+      year: 2006,
+      url: 'http...',
+      id: '...',
+      body: [
+        {
+          tags: ['aml'],
+          text: 'a line or paragraph',
+          offset: 0
+        }
+      ]
+    }
+  ]
+};

--- a/server/src/router/query.route.js
+++ b/server/src/router/query.route.js
@@ -1,5 +1,5 @@
-export default () => (req, res) => {
-  const { countries, categories } = req.query;
+import results from '../fixtures/query-results';
 
-  res.json({ data: 'RESULTS' });
+export default () => (req, res) => {
+  res.json({ data: results });
 };


### PR DESCRIPTION
- `snake_case` keys -> `camelCase`
- reserved word `type` -> `type_`
- JSON `array` -> ELM `List`

Set up to decode JSON response of the form
```
{
  "n_matches": 10,              -- number of matches in this response
  "total_matches": 100,         -- total number of matches
  "max_score": 1.5,
  "matches": [
    {                           -- matches are listed document by document
      "score": 1.5,
      "title": "Title",
      "type": "act",            -- the document type (if available)
      "country": "MM",          -- ISO country code (or an invented code): see etc/countries.json
      "year": 2006,             -- the year of publication/enactment (if available)
      "url": "http...",         -- the original document
      "id": "...",              -- our document ID can be used to access a plaintext snapshot
      "body": [{                -- some relevant blocks of text, in occurrence order
        "tags": ["aml", ...],   -- the taxonomy labels applied to this block of text
        "text": "a line or paragraph",
        "offset": 0             -- the offset of this block within the plaintext snapshot
      }]
    }, ...
  ]
}
```