### PR TITLE
Making body optional in queryDecoder

### DIFF
--- a/client/src/Data/QueryDecoder.elm
+++ b/client/src/Data/QueryDecoder.elm
@@ -51,7 +51,7 @@ matchDecoder =
         |> required "year" (nullable int)
         |> required "url" string
         |> required "id" string
-        |> required "body" (list matchBodyDecoder)
+        |> optional "body" (list matchBodyDecoder) []
 
 
 decoder : Decoder QueryResults

--- a/client/src/QueryResultList.elm
+++ b/client/src/QueryResultList.elm
@@ -7,7 +7,7 @@ import Html.Attributes.Aria exposing (ariaExpanded, ariaHidden, ariaControls, ar
 import Html.Events exposing (onClick)
 import Model exposing (Model, Msg(..))
 import Set
-import Util exposing (boolStr, (!!))
+import Util exposing (boolStr, (!!), viewIf)
 
 
 view : Model -> Html Msg
@@ -54,12 +54,15 @@ view model =
 
                             emptyBody =
                                 { tags = []
-                                , text = ""
+                                , text = "This result contains no body. It matched your search terms against its title only."
                                 , offset = 0
-                                , summary = ""
+                                , summary = match.title
                                 , url = ""
                                 , page = 0
                                 }
+
+                            matchHasBody =
+                                0 !! match.body /= Nothing
 
                             snippet =
                                 Maybe.withDefault emptyBody (0 !! match.body)
@@ -85,7 +88,8 @@ view model =
                                     ]
                                     [ div [ innerHtml snippet.text ] []
                                     , div []
-                                        [ text ("p." ++ toString snippet.page ++ ", ")
+                                        [ viewIf matchHasBody
+                                            (text ("p." ++ toString snippet.page ++ ", "))
                                         , a
                                             [ href snippet.url
                                             , target "_blank"


### PR DESCRIPTION
... and display such matches as follows:
![image](https://user-images.githubusercontent.com/12934669/42037643-d6528d36-7ae0-11e8-8938-f19482c3d4fe.png)
