### PR TITLE
Adding remote-data package for Loading and Error user feedback

### DIFF
--- a/client/elm-package.json
+++ b/client/elm-package.json
@@ -12,6 +12,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "Gizra/elm-dictlist": "2.1.2 <= v < 3.0.0",
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
         "elm-community/html-extra": "2.2.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
@@ -20,7 +21,9 @@
         "elm-lang/navigation": "2.0.0 <= v < 3.0.0",
         "evancz/url-parser": "2.0.0 <= v < 3.0.0",
         "fapian/elm-html-aria": "1.3.0 <= v < 2.0.0",
-        "gaborv/debouncer": "1.0.1 <= v < 2.0.0"
+        "gaborv/debouncer": "1.0.1 <= v < 2.0.0",
+        "krisajenkins/remotedata": "4.5.0 <= v < 5.0.0",
+        "ohanhi/remotedata-http": "2.1.0 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/client/src/Data/DataTypes.elm
+++ b/client/src/Data/DataTypes.elm
@@ -1,6 +1,34 @@
 module DataTypes exposing (..)
 
-import Dict
+import Dict exposing (Dict)
+import DictList exposing (DictList)
+import Set exposing (Set)
+
+
+type InputAlignment
+    = Left
+    | Right
+    | Center
+
+
+type alias AccordionsOpen =
+    Set ( String, Int )
+
+
+type alias CountryId =
+    String
+
+
+type alias CountryName =
+    String
+
+
+type alias CountriesDictList =
+    DictList CountryId (List CountryName)
+
+
+type alias AppData =
+    { countries : CountriesDictList, taxonomy : Taxonomy }
 
 
 type alias SearchParsed =
@@ -41,9 +69,9 @@ type alias QueryResultMatchBody =
     }
 
 
-type alias HomeDataResults =
+type alias AppDataResults =
     { taxonomy : Taxonomy
-    , countries : List ( String, List String )
+    , countries : CountriesDictList
     }
 
 
@@ -56,11 +84,21 @@ type alias Taxonomy =
     , enabled : Bool
     , name : String
     , description : String
-    , children : HomeDataChildren
+    , children : AppDataChildren
     }
 
 
-type alias HomeDataItem =
+emptyTaxonomy : Taxonomy
+emptyTaxonomy =
+    { id = ""
+    , enabled = False
+    , name = ""
+    , description = ""
+    , children = AppDataChildren []
+    }
+
+
+type alias AppDataItem =
     { id : TaxonomyId
     , enabled : Bool
     , name : String
@@ -68,5 +106,5 @@ type alias HomeDataItem =
     }
 
 
-type HomeDataChildren
-    = HomeDataChildren (List Taxonomy)
+type AppDataChildren
+    = AppDataChildren (List Taxonomy)

--- a/client/src/Data/QueryDecoder.elm
+++ b/client/src/Data/QueryDecoder.elm
@@ -5,6 +5,7 @@ import Model exposing (Model, Msg(..))
 import DataTypes exposing (QueryResults, QueryResult, QueryResultMatch, QueryResultMatchBody)
 import Json.Decode exposing (Decoder, list, int, float, string, at, oneOf, null, nullable)
 import Json.Decode.Pipeline exposing (decode, required, optional, hardcoded)
+import RemoteData
 
 
 request : Model -> Http.Request QueryResults
@@ -27,7 +28,9 @@ nullableString =
 
 requestCmd : Model -> Cmd Msg
 requestCmd model =
-    Http.send FetchQueryResults (request model)
+    request model
+        |> RemoteData.sendRequest
+        |> Cmd.map FetchQueryResults
 
 
 matchBodyDecoder : Decoder QueryResultMatchBody

--- a/client/src/FilterTextInput.elm
+++ b/client/src/FilterTextInput.elm
@@ -10,10 +10,10 @@ import Model exposing (Model, Msg(FilterTextOnInput))
 view : Model -> Html Msg
 view model =
     div
-        [ class "w-20 fl relative icon icon--search z-0" ]
+        [ class "w-100 fl relative icon icon--search z-0" ]
         [ input
             [ class "w-100 h2 pv2 pl4 bg-transparent bn f7 dark-gray metro truncate-ns placeholder--filter-text relative z-1"
-            , type_ "text"
+            , type_ "search"
             , onInput FilterTextOnInput
             , placeholder "Search results..."
             , value model.filterText

--- a/client/src/Helpers/AppData.elm
+++ b/client/src/Helpers/AppData.elm
@@ -1,18 +1,19 @@
-module Helpers.HomeData exposing (getActivities, getCategories, getCountries, getCountriesDict, getCountryName)
+module Helpers.AppData exposing (getActivities, getCategories, getCountries, getCountriesDict, getCountryName)
 
-import DataTypes exposing (HomeDataItem, Taxonomy, HomeDataChildren(..))
+import DataTypes exposing (AppDataItem, Taxonomy, AppDataChildren(..), CountryId, CountryName, CountriesDictList)
 import ActivitySelect exposing (Activity, ActivityId)
-import CountrySelect exposing (Country, CountryId, CountryName)
+import CountrySelect exposing (Country)
 import Util exposing ((!!))
 import Dict
+import DictList
 
 
-removeChildren : List Taxonomy -> List HomeDataItem
+removeChildren : List Taxonomy -> List AppDataItem
 removeChildren taxonomies =
     taxonomies
         |> List.map
             (\taxonomy ->
-                HomeDataItem
+                AppDataItem
                     taxonomy.id
                     taxonomy.enabled
                     taxonomy.name
@@ -28,20 +29,20 @@ getFirstLevelChildren :
             , id : String
             , name : String
             , description : String
-            , children : HomeDataChildren
+            , children : AppDataChildren
             }
 getFirstLevelChildren taxonomy =
-    (\(HomeDataChildren children) -> children) taxonomy.children
+    (\(AppDataChildren children) -> children) taxonomy.children
 
 
-getActivities : Taxonomy -> List HomeDataItem
+getActivities : Taxonomy -> List AppDataItem
 getActivities taxonomy =
     taxonomy
         |> getFirstLevelChildren
         |> removeChildren
 
 
-getCategories : Taxonomy -> ActivityId -> List HomeDataItem
+getCategories : Taxonomy -> ActivityId -> List AppDataItem
 getCategories taxonomy activityId =
     taxonomy
         |> getFirstLevelChildren
@@ -52,7 +53,7 @@ getCategories taxonomy activityId =
             , name = ""
             , enabled = False
             , description = ""
-            , children = HomeDataChildren []
+            , children = AppDataChildren []
             }
         |> getFirstLevelChildren
         |> removeChildren
@@ -80,5 +81,8 @@ getCountriesDict countryList =
         |> Dict.fromList
 
 
-getCountryName countryId model =
-    Maybe.withDefault "" (Dict.get countryId model.countries)
+getCountryName : CountryId -> CountriesDictList -> CountryName
+getCountryName countryId countriesDictList =
+    DictList.get countryId countriesDictList
+        |> Maybe.andThen List.head
+        |> Maybe.withDefault ""

--- a/client/src/Helpers/CountrySelect.elm
+++ b/client/src/Helpers/CountrySelect.elm
@@ -1,8 +1,9 @@
 module Helpers.CountrySelect exposing (getCountrySelect, getSelectedCountry)
 
 import Model exposing (Model)
-import CountrySelect exposing (CountryId)
+import CountrySelect
 import Dict
+import DataTypes exposing (CountryId)
 
 
 getCountrySelect : Int -> Model -> CountrySelect.Model

--- a/client/src/Helpers/QueryString.elm
+++ b/client/src/Helpers/QueryString.elm
@@ -1,11 +1,45 @@
-module Helpers.QueryString exposing (queryString, removeFromQueryString)
+module Helpers.QueryString exposing (queryString, removeFromQueryString, queryValidation)
 
 import Model exposing (Model)
 import Helpers.Routing exposing (parseParams)
-import Helpers.CountrySelect exposing (getCountrySelect)
+import Helpers.CountrySelect exposing (getCountrySelect, getSelectedCountry)
 import Dict
 import DataTypes exposing (SearchParsed)
 import Util exposing ((!!))
+import Validation exposing (Validation(..))
+
+
+queryValidation : Model -> Validation
+queryValidation model =
+    let
+        noActivitySelected =
+            model.activitySelect.selected == Nothing
+
+        noCategorySelected =
+            List.isEmpty model.categorySelect.selected
+
+        noCountrySelected =
+            getSelectedCountry 0 model == Nothing
+
+        validationText =
+            if noActivitySelected then
+                "Please select an Activity"
+            else if noCategorySelected then
+                "Please select a Category"
+            else if noCountrySelected then
+                "Please select a Country"
+            else
+                ""
+
+        inValidQuery =
+            noActivitySelected || noCategorySelected || noCountrySelected
+    in
+        case inValidQuery of
+            True ->
+                Invalid validationText
+
+            False ->
+                Valid
 
 
 queryString : Model -> String

--- a/client/src/Helpers/QueryString.elm
+++ b/client/src/Helpers/QueryString.elm
@@ -31,10 +31,10 @@ queryValidation model =
             else
                 ""
 
-        inValidQuery =
+        invalidQuery =
             noActivitySelected || noCategorySelected || noCountrySelected
     in
-        case inValidQuery of
+        case invalidQuery of
             True ->
                 Invalid validationText
 

--- a/client/src/Model/Model.elm
+++ b/client/src/Model/Model.elm
@@ -3,7 +3,7 @@ module Model exposing (Msg(..), Model, Flags, init)
 import Navigation
 import Debouncer
 import Time
-import CountrySelect exposing (CountryId, CountryName, Country)
+import CountrySelect exposing (Country)
 import ActivitySelect
 import CategorySelect exposing (CategoryId)
 import Helpers.Routing exposing (parseLocation)
@@ -14,11 +14,14 @@ import DataTypes
         ( QueryResults
         , QueryResult
         , Taxonomy
-        , HomeDataResults
-        , HomeDataChildren(..)
+        , AppDataResults
+        , AppDataChildren(..)
         , SearchParsed
+        , AppData
+        , CountriesDictList
+        , AccordionsOpen
         )
-import Http
+import RemoteData exposing (RemoteData(..), WebData)
 
 
 type Msg
@@ -30,8 +33,8 @@ type Msg
     | CountrySelectMsg Int CountrySelect.Msg
     | ActivitySelectMsg ActivitySelect.Msg
     | CategorySelectMsg CategorySelect.Msg
-    | FetchQueryResults (Result Http.Error QueryResults)
-    | HomeData (Result Http.Error HomeDataResults)
+    | FetchQueryResults (WebData QueryResults)
+    | FetchAppData (WebData AppDataResults)
     | SetActiveCategory CategoryId
     | FilterTextOnInput String
     | OnQueryUpdate
@@ -51,9 +54,8 @@ type alias Model =
     { location : Navigation.Location
     , debouncer : Debouncer.DebouncerState
     , search : SearchParsed
-    , queryResults : List QueryResult
-    , homeData : Taxonomy
-    , countries : Dict.Dict CountryId CountryName
+    , queryResults : WebData QueryResults
+    , appData : WebData AppData
     , email : String
     , isLoggedIn : Bool
     , countrySelect : Dict Int CountrySelect.Model
@@ -62,7 +64,7 @@ type alias Model =
     , activeCategory : Maybe CategoryId
     , filterText : String
     , categorySubMenuOpen : Maybe CategoryId
-    , accordionsOpen : Set.Set ( String, Int )
+    , accordionsOpen : AccordionsOpen
     , config : { apiBaseUrl : String }
     , navCount : Int
     , config : Flags
@@ -74,15 +76,8 @@ init flags location =
     ( { location = parseLocation location
       , search = Dict.empty
       , debouncer = Debouncer.create (0.3 * Time.second)
-      , queryResults = []
-      , homeData =
-            { id = ""
-            , enabled = False
-            , name = ""
-            , description = ""
-            , children = HomeDataChildren []
-            }
-      , countries = Dict.empty
+      , queryResults = NotAsked
+      , appData = Loading
       , email = ""
       , isLoggedIn = False
       , countrySelect =

--- a/client/src/QueryNavBar.elm
+++ b/client/src/QueryNavBar.elm
@@ -1,6 +1,6 @@
 module QueryNavBar exposing (..)
 
-import Html exposing (Html, nav, div, button, a, text)
+import Html exposing (Html, nav, div, button, a, text, span)
 import Html.Attributes exposing (class)
 import Model exposing (Model, Msg(..))
 import CountrySelect
@@ -9,6 +9,8 @@ import ActivitySelect
 import CategorySelect
 import FilterTextInput
 import Set
+import RemoteData exposing (RemoteData(..))
+import DataTypes exposing (InputAlignment(..))
 
 
 divider : Html msg
@@ -19,43 +21,51 @@ divider =
 view : Model -> Html Msg
 view model =
     let
-        inputAlignment =
-            case model.location.hash of
-                "#/query" ->
-                    "left"
-
-                _ ->
-                    "right"
+        loadingGreyedTextEffect =
+            span [ class "dib w-100 h-100 bg-mid-gray br2" ] []
 
         options =
-            { inputAlignment = inputAlignment }
+            { inputAlignment = Left
+            , loadingButtonInner =
+                case model.appData of
+                    Success appData ->
+                        Nothing
+
+                    _ ->
+                        Just loadingGreyedTextEffect
+            }
     in
         nav [ class "flex justify-between bb b--gray pv2" ]
             [ div [ class "bg-mid-gray br-pill pa2 w-90 ml2 ba b--moon-gray flex" ]
                 [ div
-                    [ class "w-20 mr2" ]
+                    [ class "w-18 fl mr2" ]
                     [ Html.map
                         ActivitySelectMsg
                         (ActivitySelect.view model.activitySelect options)
                     ]
                 , div
-                    [ class "w-20" ]
+                    [ class "w-18 fl" ]
                     [ Html.map
                         CategorySelectMsg
                         (CategorySelect.view model.categorySelect options)
                     ]
                 , divider
                 , div
-                    [ class "w-20" ]
+                    [ class "w-18 fl" ]
                     [ Html.map
                         (CountrySelectMsg 0)
                         (CountrySelect.view
                             (getCountrySelect 0 model)
-                            { excludedCountries = Set.empty, placeholderText = Nothing }
+                            { excludedCountries = Set.empty
+                            , placeholderText = Nothing
+                            , maxOptionsToShow = 8
+                            , loadingInputInner = Just loadingGreyedTextEffect
+                            , required = True
+                            }
                         )
                     ]
                 , div
-                    [ class "w-20 ml2" ]
+                    [ class "w-18 fl ml2" ]
                     [ Html.map
                         (CountrySelectMsg 1)
                         (CountrySelect.view
@@ -68,10 +78,13 @@ view model =
                                     Nothing ->
                                         Set.empty
                             , placeholderText = Just "Compare with..."
+                            , maxOptionsToShow = 8
+                            , loadingInputInner = Just loadingGreyedTextEffect
+                            , required = False
                             }
                         )
                     ]
                 , divider
-                , FilterTextInput.view model
+                , div [ class "w-18" ] [ FilterTextInput.view model ]
                 ]
             ]

--- a/client/src/SelectedCategories.elm
+++ b/client/src/SelectedCategories.elm
@@ -1,11 +1,12 @@
 module SelectedCategories exposing (..)
 
-import Html exposing (Html, section, div, a, button, input, header, img, text, ul, li, p)
+import Html exposing (Html, section, div, a, button, input, header, img, text, ul, li, p, span)
 import Html.Attributes exposing (id, class, tabindex, value, disabled, classList)
 import Html.Events exposing (onClick)
 import Model exposing (Model, Msg(Copy, CategorySubMenuClick, CategoryRemoveClick))
 import CategorySelect exposing (Category, emptyCategory, getCategoriesFromIds)
 import Helpers.CountrySelect exposing (getCountrySelect)
+import RemoteData exposing (RemoteData(..))
 
 
 subMenu : ( Model, Category ) -> Html Msg
@@ -96,11 +97,19 @@ categoriesMenu model =
                             , ( "icon--menu-dots-white", (Just category.id == model.activeCategory) )
                             , ( "icon--menu-dots-grey", (Just category.id /= model.activeCategory) )
                             ]
+
+                    buttonInner =
+                        case model.appData of
+                            Loading ->
+                                span [ class "dib w-100 h1 bg-mid-gray br2" ] []
+
+                            _ ->
+                                text category.name
                 in
                     li [ class "relative" ]
                         [ button
                             [ categoryClass, onClick (Model.SetActiveCategory category.id), tabindex 0 ]
-                            [ text category.name ]
+                            [ buttonInner ]
                         , button [ categoryMenuDotsClass, onClick (CategorySubMenuClick category.id) ] []
                         , subMenu ( model, category )
                         ]

--- a/client/src/Validation.elm
+++ b/client/src/Validation.elm
@@ -1,0 +1,10 @@
+module Validation exposing (Validation(..))
+
+
+type alias Msg =
+    String
+
+
+type Validation
+    = Valid
+    | Invalid Msg

--- a/client/src/Views/Home.elm
+++ b/client/src/Views/Home.elm
@@ -35,7 +35,7 @@ view model =
         , section
             [ class "flex justify-center items-center" ]
             [ case model.appData of
-                Failure error ->
+                Failure _ ->
                     div [ class "w-60 mt3" ] [ text "There was a problem connecting to our servers. Please check your internet connection and try again." ]
 
                 _ ->

--- a/client/src/Views/Home.elm
+++ b/client/src/Views/Home.elm
@@ -4,14 +4,15 @@ import Model exposing (Model, Msg(..))
 import Html exposing (Html, text, div, section, form, img, input, h1, button, span, a, p)
 import Html.Attributes exposing (type_, placeholder, value, src, class, href, tabindex, classList)
 import Html.Attributes.Aria exposing (role)
-import Html.Events exposing (onSubmit, onInput)
-import Util exposing (viewIf)
 import CountrySelect
 import Helpers.CountrySelect exposing (getCountrySelect)
 import ActivitySelect
 import CategorySelect
-import Helpers.QueryString exposing (queryString)
+import Helpers.QueryString exposing (queryString, queryValidation)
+import Validation exposing (Validation(..))
+import RemoteData exposing (RemoteData(..))
 import Set
+import DataTypes exposing (InputAlignment(..))
 
 
 view : Model -> Html Msg
@@ -31,46 +32,61 @@ view model =
                     ]
                 ]
             ]
+        , section
+            [ class "flex justify-center items-center" ]
+            [ case model.appData of
+                Failure error ->
+                    div [ class "w-60 mt3" ] [ text "There was a problem connecting to our servers. Please check your internet connection and try again." ]
+
+                _ ->
+                    text ""
+            ]
         ]
 
 
 queryForm : Model -> Html Msg
 queryForm model =
-    let
-        inputAlignment =
-            case model.location.hash of
-                "#/query" ->
-                    "left"
-
-                "#/" ->
-                    "right"
-
-                _ ->
-                    "right"
-
-        options =
-            { inputAlignment = inputAlignment }
-    in
-        form [ class "flex", role "search", onSubmit SubmitLoginEmailForm ]
-            [ div
-                [ class "w-30" ]
-                [ Html.map
-                    (CountrySelectMsg 0)
-                    (CountrySelect.view
-                        (getCountrySelect 0 model)
-                        { excludedCountries = Set.empty, placeholderText = Nothing }
-                    )
-                ]
-            , divider
-            , div
-                [ class "w-30" ]
-                [ Html.map ActivitySelectMsg (ActivitySelect.view model.activitySelect options) ]
-            , divider
-            , div
-                [ class "w-30 relative" ]
-                [ Html.map CategorySelectMsg (CategorySelect.view model.categorySelect options) ]
-            , submitButton model
+    form [ class "flex", role "search" ]
+        [ div
+            [ class "w-30" ]
+            [ Html.map
+                (CountrySelectMsg 0)
+                (CountrySelect.view
+                    (getCountrySelect 0 model)
+                    { excludedCountries = Set.empty
+                    , placeholderText = Nothing
+                    , maxOptionsToShow = 8
+                    , loadingInputInner = Nothing
+                    , required = True
+                    }
+                )
             ]
+        , divider
+        , div
+            [ class "w-30" ]
+            [ Html.map
+                ActivitySelectMsg
+                (ActivitySelect.view
+                    model.activitySelect
+                    { inputAlignment = Center
+                    , loadingButtonInner = Nothing
+                    }
+                )
+            ]
+        , divider
+        , div
+            [ class "w-30 relative" ]
+            [ Html.map
+                CategorySelectMsg
+                (CategorySelect.view
+                    model.categorySelect
+                    { inputAlignment = Right
+                    , loadingButtonInner = Nothing
+                    }
+                )
+            ]
+        , submitButton model
+        ]
 
 
 divider : Html msg
@@ -78,44 +94,29 @@ divider =
     div [ class "w-05 fl h2 flex justify-center" ] [ div [ class "br b--light-gray w0 h2 mh0" ] [] ]
 
 
-checkFormValid : Model -> Bool
-checkFormValid model =
-    model.activitySelect.selected
-        /= Nothing
-        && .selected (getCountrySelect 0 model)
-        /= Nothing
-        && not (List.isEmpty model.categorySelect.selected)
-
-
 submitButton : Model -> Html msg
 submitButton model =
     let
-        isFormValid =
-            checkFormValid model
-
-        buttonChildclass =
-            classList
-                [ ( "flex justify-center items-center no-underline br-100 bg-blue white f5 metro bn h-100 w-100"
-                  , True
-                  )
-                , ( "ma0 disabled bg-washed-blue"
-                  , not isFormValid
-                  )
-                ]
+        buttonChildClass =
+            "flex justify-center items-center no-underline br-100 bg-blue white f5 metro bn h-100 w-100"
     in
-        button [ class "di pa2 absolute right--2 top-0 h3 w3 bg-transparent bn", tabindex -1 ]
-            [ viewIf isFormValid
-                (a
-                    [ href ("/#/query?" ++ (queryString model))
-                    , buttonChildclass
-                    , value "submit"
-                    ]
-                    [ text "Go" ]
-                )
-            , viewIf (not isFormValid)
-                (span
-                    [ buttonChildclass
-                    ]
-                    [ text "Go" ]
-                )
+        button
+            [ class "di pa2 absolute right--2 top-0 h3 w3 bg-transparent bn"
+            , tabindex -1
+            , type_ "button"
+            ]
+            [ case queryValidation model of
+                Valid ->
+                    a
+                        [ href ("/#/query?" ++ (queryString model))
+                        , class buttonChildClass
+                        , value "submit"
+                        ]
+                        [ text "Go" ]
+
+                Invalid reason ->
+                    span
+                        [ class (buttonChildClass ++ "ma0 disabled bg-washed-blue")
+                        ]
+                        [ text "Go" ]
             ]

--- a/client/src/css/_custom.css
+++ b/client/src/css/_custom.css
@@ -80,6 +80,10 @@ button {
   width: 5%;
 }
 
+.w-18 {
+  width: 18%;
+}
+
 .w15rem {
   width: 15rem;
 }

--- a/client/src/css/_flags.css
+++ b/client/src/css/_flags.css
@@ -18,6 +18,9 @@
 .flag-icon.flag-icon-squared {
   width: 1em;
 }
+.flag-icon {
+  background-image: url(../assets/icons/flag.svg);
+}
 .flag-icon-ad {
   background-image: url(../assets/flags/4x3/ad.svg);
 }

--- a/client/src/css/_spinner.css
+++ b/client/src/css/_spinner.css
@@ -1,0 +1,20 @@
+@keyframes spinner {
+  to {transform: rotate(360deg);}
+}
+
+.spinner::before {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  margin-top: -15px;
+  margin-left: -15px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  /* --blue */
+  border-top-color: #0071bc;
+  animation: spinner .6s linear infinite;
+}

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -61,3 +61,4 @@
 @import './_custom';
 @import './_icons';
 @import './_flags';
+@import './_spinner';

--- a/server/__test__/router/app-data.test.js
+++ b/server/__test__/router/app-data.test.js
@@ -2,10 +2,10 @@ import request from 'supertest';
 
 const app = process.app;
 
-describe('GET /home-data', () => {
+describe('GET /app-data', () => {
   test('200 and correct data in response', done => {
     return request(app)
-      .get('/api/home-data')
+      .get('/api/app-data')
       .send()
       .end((err, res) => {
         if (err) return done(err);

--- a/server/src/router/app-data.route.js
+++ b/server/src/router/app-data.route.js
@@ -2,9 +2,9 @@ export default ({ searchApiService }) => async (req, res, next) => {
   const { fetchTaxonomy, fetchCountries } = searchApiService;
 
   try {
-    const homeDataRes = await Promise.all([fetchTaxonomy(), fetchCountries()]);
+    const appDataRes = await Promise.all([fetchTaxonomy(), fetchCountries()]);
 
-    const [{ data: taxonomy }, { data: countries }] = homeDataRes;
+    const [{ data: taxonomy }, { data: countries }] = appDataRes;
 
     res.json({
       data: { taxonomy, countries }

--- a/server/src/router/index.js
+++ b/server/src/router/index.js
@@ -6,7 +6,7 @@ import querySchema from '../validations/query.validation';
 
 import loginEmail from './login-email.route';
 import query from './query.route';
-import homeData from './home-data.route';
+import appData from './app-data.route';
 
 const createRouter = dependencies => {
   const router = Router();
@@ -23,7 +23,7 @@ const createRouter = dependencies => {
 
   router.get('/query', validate(querySchema), query(dependencies));
 
-  router.get('/home-data', homeData(dependencies));
+  router.get('/app-data', appData(dependencies));
 
   return router;
 };


### PR DESCRIPTION
- also fixes #106 , bug which allows users to select countries which they can't see

- adds grey text effect to inputs when appData is loading
![image](https://user-images.githubusercontent.com/12934669/42294283-6f881a34-7fd7-11e8-8d73-ff051eda7c8e.png)

- adds loading spinner when queryResults is loading 
![image](https://user-images.githubusercontent.com/12934669/42294317-d875a138-7fd7-11e8-906f-7e1c793ad8b2.png)

- adds placeholder flags when we don't have flags for the country
![image](https://user-images.githubusercontent.com/12934669/42295097-c55b07e4-7fde-11e8-95a6-1a0dafe89155.png)

- adds error if appData request results in `Failure`
![image](https://user-images.githubusercontent.com/12934669/42311643-3edfeca4-8036-11e8-960b-5b28338b81d4.png)

